### PR TITLE
fix: Update repository clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ name_machine_prefix = "my-project"  # Custom prefix / Préfixe personnalisé
 
 ```bash
 # Clone repository / Cloner le dépôt
-git clone https://github.com/your-username/aws-terraform-ansible.git
-cd aws-terraform-ansible/terraform
+git clone https://github.com/Foufou-exe/iac-terraform-ansible-aws-webserver-demo/aws-terraform-ansible.git
+cd iac-terraform-ansible-aws-webserver-demo/terraform
 ```
 
 ### 🔧 Étape 2 : Initialiser Terraform / Step 2: Initialize Terraform


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect changes in the repository URL and directory structure for cloning and navigating the project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L219-R220): Updated the repository URL to `https://github.com/Foufou-exe/iac-terraform-ansible-aws-webserver-demo/aws-terraform-ansible.git` and adjusted the directory path to `iac-terraform-ansible-aws-webserver-demo/terraform` for cloning and navigating the project.

## Summary by Sourcery

Documentation:
- Update the repository clone URL and adjust the directory path in README.md